### PR TITLE
Added semantic view privileges, and fixed some formatting.

### DIFF
--- a/lib/backends/terraform/terraformVersion.ts
+++ b/lib/backends/terraform/terraformVersion.ts
@@ -3,5 +3,5 @@ import {SchemaObjectGrantKind} from '../../grants/schemaObjectGrant'
 export const TERRAFORM_VERSION = '0.64.0'
 
 export const NO_SHARES_IN_ID_RESOURCES: SchemaObjectGrantKind[] = [
-  'dynamic_table', 'file_format', 'sequence', 'stage', 'stream', 'task'
+  'dynamic_table', 'file_format', 'semantic_view', 'sequence', 'stage', 'stream', 'task'
 ]

--- a/lib/grants/dynamicTableGrant.ts
+++ b/lib/grants/dynamicTableGrant.ts
@@ -1,17 +1,17 @@
-import { Schema } from '../objects/schema';
-import { Role } from '../roles/role';
-import { Privilege } from '../privilege';
-import { SchemaObjectGrant, SchemaObjectGrantKind } from './schemaObjectGrant';
-import { Grant } from './grant';
+import { Schema } from '../objects/schema'
+import { Role } from '../roles/role'
+import { Privilege } from '../privilege'
+import { SchemaObjectGrant, SchemaObjectGrantKind } from './schemaObjectGrant'
+import { Grant } from './grant'
 
 export class DynamicTableGrant extends SchemaObjectGrant {
-  schema: Schema;
-  dynamicTable?: { name: string };  // Using a simple object since there's no DynamicTable class yet
-  future: boolean;
-  privilege: Privilege;
-  role: Role;
-  dependsOn?: Grant[];
-  kind: SchemaObjectGrantKind = 'dynamic_table';
+  schema: Schema
+  dynamicTable?: { name: string }  // Using a simple object since there's no DynamicTable class yet
+  future: boolean
+  privilege: Privilege
+  role: Role
+  dependsOn?: Grant[]
+  kind: SchemaObjectGrantKind = 'dynamic_table'
 
   constructor(
     schema: Schema,
@@ -21,16 +21,16 @@ export class DynamicTableGrant extends SchemaObjectGrant {
     dynamicTable?: { name: string },
     dependsOn?: Grant[]
   ) {
-    super();
-    this.schema = schema;
-    this.dynamicTable = dynamicTable;
-    this.future = future;
-    this.privilege = privilege;
-    this.role = role;
-    this.dependsOn = dependsOn;
+    super()
+    this.schema = schema
+    this.dynamicTable = dynamicTable
+    this.future = future
+    this.privilege = privilege
+    this.role = role
+    this.dependsOn = dependsOn
   }
 
   objectName(): string | undefined {
-    return this.dynamicTable?.name;
+    return this.dynamicTable?.name
   }
 }

--- a/lib/grants/schemaObjectGrant.ts
+++ b/lib/grants/schemaObjectGrant.ts
@@ -4,7 +4,7 @@ import {Privilege} from '../privilege'
 import {Grant, GrantType} from './grant'
 import {Database} from '../objects/database'
 
-export const SchemaObjectGrantKinds = ['dynamic_table', 'file_format', 'function', 'materialized_view', 'procedure', 'sequence', 'stage', 'stream', 'table', 'task', 'view'];
+export const SchemaObjectGrantKinds = ['semantic_view','dynamic_table', 'file_format', 'function', 'materialized_view', 'procedure', 'sequence', 'stage', 'stream', 'table', 'task', 'view'];
 export type SchemaObjectGrantKind = typeof SchemaObjectGrantKinds[number]
 
 export abstract class SchemaObjectGrant implements Grant {

--- a/lib/grants/semanticViewGrant.ts
+++ b/lib/grants/semanticViewGrant.ts
@@ -1,0 +1,36 @@
+import {Schema} from '../objects/schema'
+import {Role} from '../roles/role'
+import {Privilege} from '../privilege'
+import {SchemaObjectGrant, SchemaObjectGrantKind} from './schemaObjectGrant'
+import {Grant} from './grant'
+
+export class SemanticViewGrant extends SchemaObjectGrant {
+  schema: Schema
+  semanticView?: { name: string }
+  future: boolean
+  privilege: Privilege
+  role: Role
+  dependsOn?: Grant[]
+  kind: SchemaObjectGrantKind = 'semantic_view'
+
+  constructor(
+    schema: Schema,
+    future: boolean,
+    privilege: Privilege,
+    role: Role,
+    semanticView?: { name: string },
+    dependsOn?: Grant[]
+  ) {
+    super()
+    this.schema = schema
+    this.semanticView = semanticView
+    this.future = future
+    this.privilege = privilege
+    this.role = role
+    this.dependsOn = dependsOn
+  }
+
+  objectName(): string | undefined {
+    return this.semanticView?.name
+  }
+}

--- a/lib/objects/semanticView.ts
+++ b/lib/objects/semanticView.ts
@@ -1,6 +1,6 @@
 import { Schema } from './schema'
 
-export class DynamicTable {
+export class SemanticView {
   name: string
   schema: Schema
 

--- a/lib/roles/schemaAccessRole.ts
+++ b/lib/roles/schemaAccessRole.ts
@@ -18,6 +18,7 @@ import {TaskGrant} from '../grants/taskGrant'
 import {SequenceGrant} from '../grants/sequenceGrant'
 import {MaterializedViewGrant} from '../grants/materializedViewGrant'
 import {DynamicTableGrant} from '../grants/dynamicTableGrant'
+import {SemanticViewGrant} from '../grants/semanticViewGrant'
 
 export class SchemaAccessRole implements AccessRole {
   schema: Schema
@@ -86,6 +87,10 @@ export class SchemaAccessRole implements AccessRole {
       new DynamicTableGrant(this.schema, true, Privilege.SELECT, this, undefined, [schemaOwnerGrant]),
       new DynamicTableGrant(this.schema, false, Privilege.MONITOR, this, undefined, [schemaOwnerGrant]),
       new DynamicTableGrant(this.schema, true, Privilege.MONITOR, this, undefined, [schemaOwnerGrant]),
+      new SemanticViewGrant(this.schema, false, Privilege.SELECT, this, undefined, [schemaOwnerGrant]),
+      new SemanticViewGrant(this.schema, true, Privilege.SELECT, this, undefined, [schemaOwnerGrant]),
+      new SemanticViewGrant(this.schema, false, Privilege.REFERENCES, this, undefined, [schemaOwnerGrant]),
+      new SemanticViewGrant(this.schema, true, Privilege.REFERENCES, this, undefined, [schemaOwnerGrant]),
     ]
 
     const readWriteGrants = () =>
@@ -134,6 +139,8 @@ export class SchemaAccessRole implements AccessRole {
         new TaskGrant(this.schema, false, Privilege.OWNERSHIP, this, undefined, [schemaOwnerGrant]),
         new TaskGrant(this.schema, true, Privilege.OWNERSHIP, this, undefined, [schemaOwnerGrant]),
         new SchemaGrant(this.schema, Privilege.CREATE_DYNAMIC_TABLE, this),
+        new SemanticViewGrant(this.schema, false, Privilege.OWNERSHIP, this, undefined, [schemaOwnerGrant]),
+        new SemanticViewGrant(this.schema, true, Privilege.OWNERSHIP, this, undefined, [schemaOwnerGrant]),
       ].concat(readWriteGrants())
     }
 


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><h1>Add Semantic View Support to Schema Access Roles</h1>
<h2>Summary</h2>
<p>This PR adds support for Snowflake Semantic Views in the role-based access control system. Semantic views now have appropriate permissions granted at different access levels following the standard schema object pattern.</p>
<h2>Changes Made</h2>
<h3>New Files</h3>
<ul>
<li><strong><code>lib/grants/semanticViewGrant.ts</code></strong> - New grant class for semantic view permissions</li>
<li><strong><code>lib/objects/semanticView.ts</code></strong> - Semantic view object definition</li>
</ul>
<h3>Modified Files</h3>
<h4>Core Grant System</h4>
<ul>
<li><strong><code>lib/grants/schemaObjectGrant.ts</code></strong>
<ul>
<li>Added <code>'semantic_view'</code> to <code>SchemaObjectGrantKinds</code> array</li>
</ul>
</li>
<li><strong><code>lib/roles/schemaAccessRole.ts</code></strong>
<ul>
<li>Added semantic view permissions:
<ul>
<li><strong>Read</strong>: SELECT + REFERENCES on semantic views</li>
<li><strong>ReadWrite</strong>: Inherits Read permissions</li>
<li><strong>Full</strong>: Inherits ReadWrite + OWNERSHIP on semantic views</li>
</ul>
</li>
<li>Added import for <code>SemanticViewGrant</code></li>
</ul>
</li>
</ul>
<h4>Terraform Support</h4>
<ul>
<li><strong><code>lib/backends/terraform/terraformVersion.ts</code></strong>
<ul>
<li>Added <code>'semantic_view'</code> to <code>NO_SHARES_IN_ID_RESOURCES</code> array</li>
</ul>
</li>
</ul>
<h2>Permission Structure</h2>

Access Level | Permissions
-- | --
Read | SELECT, REFERENCES on ALL/FUTURE semantic views
ReadWrite | Inherits Read (no additional permissions)
Full | Inherits ReadWrite + OWNERSHIP on ALL/FUTURE semantic views


<h2>Generated SQL Example</h2>
<p>For FULL access role:</p>
<pre><code class="language-sql">GRANT SELECT ON ALL SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
GRANT SELECT ON FUTURE SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
GRANT REFERENCES ON ALL SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
GRANT REFERENCES ON FUTURE SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
GRANT OWNERSHIP ON ALL SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
GRANT OWNERSHIP ON FUTURE SEMANTIC VIEWS IN SCHEMA "PROD_REPORT_DB"."STANDARD" TO ROLE "PROD_REPORT_DB_STANDARD_FULL_AR";
</code></pre>